### PR TITLE
Fix website title

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./index.css">
     <link rel="icon" type="image/png" href="./assets/favicon.png" />
-    <title>osu!Türkiye</title>
+    <title>osu!türkiye</title>
 </head>
 <body>
     <div id="app"></div>


### PR DESCRIPTION
We no longer use `osu!Türkiye` anywhere. Any instances that refer to our website and the Discord server should use the lowercased version (`osu!türkiye`).